### PR TITLE
Add DeepSeek chat page with MCP integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,20 +56,19 @@ async def _mcp_add_transaction(data: dict) -> str:
     time_str = dt.isoformat().replace("+00:00", "Z")
 
     payload = {
+        "name": "add_transaction",
         "arguments": {
             "type": "expense",
             "time": time_str,
             "category_name": data["category"],
             "account_name": data["account"],
             "amount": str(data["amount"]),
-        }
+        },
     }
 
     headers = {"Authorization": f"Bearer {MCP_TOKEN}"}
     async with httpx.AsyncClient(timeout=10) as client:
-        response = await client.post(
-            f"{MCP_URL}/call/add_transaction", json=payload, headers=headers
-        )
+        response = await client.post(f"{MCP_URL}/call", json=payload, headers=headers)
     response.raise_for_status()
     try:
         data = response.json()

--- a/app.py
+++ b/app.py
@@ -1,0 +1,50 @@
+import os
+from typing import List
+
+from fastapi import FastAPI, Form, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+import httpx
+
+app = FastAPI()
+templates = Jinja2Templates(directory="templates")
+
+messages: List[dict] = []
+
+DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY", "")
+DEEPSEEK_API_BASE = os.getenv("DEEPSEEK_API_BASE", "https://api.deepseek.com/v1")
+MCP_URL = os.getenv("EZBOOKKEEPING_MCP_URL", "")
+MCP_TOKEN = os.getenv("EZBOOKKEEPING_MCP_TOKEN", "")
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request, "messages": messages})
+
+
+@app.post("/chat", response_class=HTMLResponse)
+async def chat(request: Request, message: str = Form(...)):
+    messages.append({"role": "user", "content": message})
+
+    payload = {
+        "model": "deepseek-chat",
+        "messages": messages,
+        "mcpServers": {
+            "ezbookkeeping-mcp": {
+                "type": "streamable-http",
+                "url": MCP_URL,
+                "headers": {"Authorization": f"Bearer {MCP_TOKEN}"},
+            }
+        },
+    }
+
+    headers = {"Authorization": f"Bearer {DEEPSEEK_API_KEY}"}
+    async with httpx.AsyncClient(base_url=DEEPSEEK_API_BASE, timeout=60) as client:
+        response = await client.post("/chat/completions", json=payload, headers=headers)
+        response.raise_for_status()
+        data = response.json()
+
+    reply = data["choices"][0]["message"]["content"]
+    messages.append({"role": "assistant", "content": reply})
+    return templates.TemplateResponse("index.html", {"request": request, "messages": messages})
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
+fastapi
+httpx
+jinja2
+uvicorn
 fastmcp>=2.11.3
-"mcp[cli]"
+mcp[cli]

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>DeepSeek Bookkeeping Chat</title>
+</head>
+<body>
+    <h1>DeepSeek Bookkeeping Chat</h1>
+    <form action="/chat" method="post">
+        <textarea name="message" rows="4" cols="60"></textarea><br>
+        <button type="submit">Send</button>
+    </form>
+    <div>
+    {% for m in messages %}
+        <p><strong>{{ m.role }}:</strong> {{ m.content }}</p>
+    {% endfor %}
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add FastAPI chat interface for DeepSeek that forwards messages with MCP server configuration
- provide simple HTML page for entering and displaying conversation
- declare required FastAPI and HTTP dependencies

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c81f6966948329a654c18711276a70